### PR TITLE
#32: add validation for uncommitted changes (closes #32)

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -31,7 +31,8 @@ const Config = t.interface({
   }),
   publish: t.maybe(t.interface({
     branch: t.maybe(t.String),
-    inSyncWithRemote: t.maybe(t.Boolean)
+    inSyncWithRemote: t.maybe(t.Boolean),
+    noUncommittedChanges: t.maybe(t.Boolean)
   }))
 });
 
@@ -43,7 +44,8 @@ const defaultConfig = {
   },
   publish: {
     branch: 'master',
-    inSyncWithRemote: true
+    inSyncWithRemote: true,
+    noUncommittedChanges: true
   }
 };
 


### PR DESCRIPTION
Issue #32

## Test Plan

### tests performed
- turn off other validations
- change a file
- run `./smooth-release --npm-publish`
  - error!

### tests not performed (domain coverage)
> At times not everything can be tested, and writing what hasn't been tested is just as important as writing what has been tested.

> An example of partial test is a field displaying 4 possible values. If 3 values are tested, with screenshots, and 1 is not, then it should be mentioned here.}
