### PR TITLE
#33: add validation for untracked files (closes #33)

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -32,7 +32,8 @@ const Config = t.interface({
   publish: t.maybe(t.interface({
     branch: t.maybe(t.String),
     inSyncWithRemote: t.maybe(t.Boolean),
-    noUncommittedChanges: t.maybe(t.Boolean)
+    noUncommittedChanges: t.maybe(t.Boolean),
+    noUntrackedFiles: t.maybe(t.Boolean)
   }))
 });
 
@@ -45,7 +46,8 @@ const defaultConfig = {
   publish: {
     branch: 'master',
     inSyncWithRemote: true,
-    noUncommittedChanges: true
+    noUncommittedChanges: true,
+    noUntrackedFiles: true
   }
 };
 


### PR DESCRIPTION
Issue #33

## Test Plan

### tests performed
- turn off other validations
- add a new empty file
- run `./smooth-release --npm-publish`
  - error!

### tests not performed (domain coverage)
> At times not everything can be tested, and writing what hasn't been tested is just as important as writing what has been tested.

> An example of partial test is a field displaying 4 possible values. If 3 values are tested, with screenshots, and 1 is not, then it should be mentioned here.}
