### PR TITLE
#38: default config should be enough to run smooth-release without errors (closes #38)

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,4 +95,4 @@ You can see an example by looking at any release on this repo: https://github.co
 
 If you want to change parts of it you can define a JSON config file in the root directory of your project named `.smooth-releaserc`.
 
-The file will be [merged](https://lodash.com/docs/4.16.6#merge) with `defaultConfig`.
+The file will be recursively merged into `defaultConfig` (NB: arrays are replaced, not merged!).

--- a/README.md
+++ b/README.md
@@ -5,8 +5,10 @@ Smart CLI utility to **safely** and **automatically** do every step to release a
 `npm i -g smooth-release`
 
 ## Usage
-1. Add [`.smooth-releaserc`](https://github.com/FrancescoCioria/smooth-release#smooth-releaserc) in your root folder
-2. Run `smooth-release` from your root folder
+Simply run `smooth-release` from your root folder, that's all :)
+
+#### Custom settings
+Every config value used by `smooth-release` is overridable: jump to [`.smooth-releaserc`](https://github.com/FrancescoCioria/smooth-release#smooth-releaserc) section to know more about it.
 
 ## What it does
 `smooth-release` does three main activities:
@@ -61,30 +63,36 @@ The release is named as the tag (ex: v1.2.3) and the body contains a link to the
 You can see an example by looking at any release on this repo: https://github.com/FrancescoCioria/smooth-release/releases.
 
 ## `.smooth-releaserc`
-Each project **must** have a JSON config file in its root folder named `.smooth-releaserc`.
+`smooth-release` comes with a safe default for each config value. This is the `defaultConfig` JSON used by `smooth-release`:
 
-The file should be structured as follows:
 ```js
 {
-  "github": {
-    "changelog": {
-      "ignoredLabels": ["invalid", "DX", "..."],
-      "bug": {
-        "title": "#### Fixes (bugs & defects):", // (or whatever you choose)
-        "labels": ["bug", "defect", "..."]
+  github: {
+    changelog: {
+      outputPath: './CHANGELOG.md',
+      ignoredLabels: ['DX', 'invalid', 'discussion'],
+      bug: {
+        title: '#### Fixes (bugs & defects):',
+        labels: ['bug', 'defect']
       },
-      "breaking": {
-        "title": "#### Breaking:", // (or whatever you choose)
-        "labels": ["breaking", "..."]
+      breaking: {
+        title: '#### Breaking:',
+        labels: ['breaking']
       },
-      "feature": {
-        "title": "#### New features:" // (or whatever you choose)
+      feature: {
+        title: '#### New features:'
       }
     }
   },
-  "publish": {
-    "branch": "master", // default: "master"; set to "false" to turn off validation
-    "inSyncWithRemote": true // set to "false" to turn off validation
+  publish: {
+    branch: 'master',
+    inSyncWithRemote: true,
+    noUncommittedChanges: true,
+    noUntrackedFiles: true
   }
 }
 ```
+
+If you want to change parts of it you can define a JSON config file in the root directory of your project named `.smooth-releaserc`.
+
+The file will be [merged](https://lodash.com/docs/4.16.6#merge) with `defaultConfig`.

--- a/src/config.js
+++ b/src/config.js
@@ -15,7 +15,7 @@ const Config = t.interface({
     token: t.maybe(t.String),
     changelog: t.interface({
       outputPath: t.String,
-      ignoredLabels: t.maybe(t.list(t.String)),
+      ignoredLabels: t.list(t.String),
       breaking: t.interface({
         title: t.String,
         labels: t.list(t.String)
@@ -29,12 +29,12 @@ const Config = t.interface({
       })
     })
   }),
-  publish: t.maybe(t.interface({
+  publish: t.interface({
     branch: t.maybe(t.String),
-    inSyncWithRemote: t.maybe(t.Boolean),
-    noUncommittedChanges: t.maybe(t.Boolean),
-    noUntrackedFiles: t.maybe(t.Boolean)
-  }))
+    inSyncWithRemote: t.Boolean,
+    noUncommittedChanges: t.Boolean,
+    noUntrackedFiles: t.Boolean
+  })
 });
 
 const defaultConfig = {

--- a/src/config.js
+++ b/src/config.js
@@ -40,7 +40,19 @@ const Config = t.interface({
 const defaultConfig = {
   github: {
     changelog: {
-      outputPath: './CHANGELOG.md'
+      outputPath: './CHANGELOG.md',
+      ignoredLabels: ['DX', 'invalid', 'discussion'],
+      bug: {
+        title: '#### Fixes (bugs & defects):',
+        labels: ['bug', 'defect']
+      },
+      breaking: {
+        title: '#### Breaking:',
+        labels: ['breaking']
+      },
+      feature: {
+        title: '#### New features:'
+      }
     }
   },
   publish: {

--- a/src/config.js
+++ b/src/config.js
@@ -8,7 +8,10 @@ t.interface.strict = true;
 
 const getRootFolderPath = () => execSync('git rev-parse --show-toplevel', { encoding: 'utf8' }).trim();
 
-const relesorc = JSON.parse(fs.readFileSync(`${getRootFolderPath()}/.smooth-releaserc`));
+const smoothReleaseRCPath = `${getRootFolderPath()}/.smooth-releaserc`;
+const smoothReleaseRC = fs.existsSync(smoothReleaseRCPath) ?
+  JSON.parse(fs.readFileSync(smoothReleaseRCPath)) :
+  {};
 
 const Config = t.interface({
   github: t.interface({
@@ -63,6 +66,6 @@ const defaultConfig = {
   }
 };
 
-const config = merge(defaultConfig, relesorc, { github: { token: getToken() } });
+const config = merge(defaultConfig, smoothReleaseRC, { github: { token: getToken() } });
 
 export default Config(config);

--- a/src/config.js
+++ b/src/config.js
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import { execSync } from 'child_process';
 import t from 'tcomb';
-import { merge } from 'lodash';
+import { mergeWith } from 'lodash';
 import getToken from './github/token';
 
 t.interface.strict = true;
@@ -66,6 +66,9 @@ const defaultConfig = {
   }
 };
 
-const config = merge(defaultConfig, smoothReleaseRC, { github: { token: getToken() } });
+const config = mergeWith(
+  defaultConfig, smoothReleaseRC, { github: { token: getToken() } },
+  (a, b) => t.Array.is(a) ? b : undefined
+);
 
 export default Config(config);


### PR DESCRIPTION
Issue #38

## Test Plan

### tests performed
- remove `.smooth-releaserc`
  - computed config is `defaultConfig` plus github token
  - `Config` validation passes
- add `.smooth-releaserc` with some overrides
  - computed config has overrides
  - `Config` validation passes
- add `.smooth-releaserc` with some overrides on an array
  - computed config has default array replaced completely with new one
  - `Config` validation passes
- add `.smooth-releaserc` formatted badly
  - `Config` validation throws error

### tests not performed (domain coverage)
> At times not everything can be tested, and writing what hasn't been tested is just as important as writing what has been tested.

> An example of partial test is a field displaying 4 possible values. If 3 values are tested, with screenshots, and 1 is not, then it should be mentioned here.}
