### PR TITLE
#53: Changelog is committed after the tag (closes #53)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,14 @@ In order to proceed each one of these validations must pass (they can be optiona
 2. Local branch must be in sync with remote
 3. No uncommited changes in the working tree
 4. No untracked filed in the working tree
+5. User must be logged in "npm" and have write permissions for current package
 
-### Increase version and push new commit and tag
+### Increase version
 
 
 #### Check if version should be considered "breaking" or not
 `smooth-release` automatically detects if the next version should be "breaking" or not.
-If a version is "breaking" it will be a `major` otherwise it wil be a `patch`.
+If a version is "breaking" it will be a `major` otherwise it will be a `patch`.
 `smooth-release` never creates a `minor` version.
 
 To decide if a version is "breaking", `smooth-release` analyzes every closed issue from GitHub: if there is **at least** one *valid* closed issue marked as "breaking" the version will be breaking.
@@ -51,35 +52,40 @@ smooth-release 5.4.6
 ```
 
 #### npm version and push
-Runs in order:
+Runs:
 
-1. `npm version ${newVersion}`
-3. `git push`
-4. `git push --tags` (never forget to push tags again!)
+1. `npm version ${newVersion} --no-git-tag-version`
 
 ### Generate CHANGELOG.md
-The script to generate the changelog is basically a replic in JavaScript of [github-changelog-generator](https://github.com/skywinder/github-changelog-generator). The only difference is that it only uses closed isses (PRs are ignored).
+The script to generate the changelog is basically a replica in JavaScript of [github-changelog-generator](https://github.com/skywinder/github-changelog-generator). The only difference is that it only uses closed issues (PRs are ignored).
 
 This script is stateless: every time it's run it replaces CHANGELOG.md with a new one.
-
-**If** the newly generated changelog is different from any previous one it automatically pushes a commit "Update CHANGELOG.md" on origin.
 
 You can see an example by looking at CHANGELOG.md file on this repo: https://github.com/FrancescoCioria/smooth-release/blob/master/CHANGELOG.md.
 
 ### Create release on GitHub with link to CHANGELOG.md section
 It statelessly creates a GitHub release for the last npm-version tag.
 
-`smooth-release` defines an *npm-version tag* as a tag named `v1.2.3` where 1, 2, 3 can be any number.
+`smooth-release` defines an *npm-version tag* as a tag named `v1.2.3` where `1`, `2`, `3` can be any number.
 
-The release is named as the tag (ex: v1.2.3) and the body contains a link to the relative section in CHANGELOG.md.
+The release is named after the tag (ex: v1.2.3) and the body contains a link to the relative section in CHANGELOG.md.
 
-You can see an example by looking at any release on this repo: https://github.com/FrancescoCioria/smooth-release/releases.
+You can see an example by looking at any release from this repo: https://github.com/FrancescoCioria/smooth-release/releases.
+
+### Create release commit and push it on origin
+This step is run only if there are changes to commit. This may happen if you run one of these scripts:
+- npm-version (modifies `package.json`)
+- changelog (modifies `CHANGELOG.md`)
+
+If the only file that changed is `CHANGELOG.md` the new commit will have as message `"Update CHANGELOG.md"`.
+
+Otherwise, if you run also `npm-version` script and therefore the `package.json` has been updated, the new commit will have the standard version message (`"1.2.3"`) and will also have the npm-version tag (`v.1.2.3`).
+
 
 ### Publish on `npm`
-Simply runs:
-```bash
-npm publish
-```
+Runs:
+
+1. `npm publish`
 
 ## `.smooth-releaserc`
 `smooth-release` comes with a safe default for each config value. This is the `defaultConfig` JSON used by `smooth-release`:
@@ -107,7 +113,8 @@ npm publish
     branch: 'master',
     inSyncWithRemote: true,
     noUncommittedChanges: true,
-    noUntrackedFiles: true
+    noUntrackedFiles: true,
+    validNpmCredentials: true
   },
   tasks: {
     validations: true,
@@ -120,7 +127,7 @@ npm publish
 }
 ```
 
-setting a task to `null` means that `smooth-release` will prompt you every time before running the task:
+If you set a task to `null`, `smooth-release` will prompt you every time before running the task:
 ![image](https://cloud.githubusercontent.com/assets/4029499/21606902/e78f23d0-d1b2-11e6-9c17-b4bccf853856.png)
 
 If you want to change parts of the default config you can define a JSON file in the root directory of your project named `.smooth-releaserc`.

--- a/src/commitAndPush.js
+++ b/src/commitAndPush.js
@@ -1,0 +1,48 @@
+import {
+  getRootFolderPath,
+  getPackageJsonVersion,
+  title,
+  status,
+  exec
+} from './utils';
+import config from './config';
+
+const stdio = [process.stdin, null, process.stderr];
+
+export default async ({ hasIncreasedVersion, hasUpdatedChangelog }) => {
+  if (!hasIncreasedVersion && !hasUpdatedChangelog) {
+    return;
+  }
+
+  title('Commit and push changes');
+
+  status.addSteps([
+    'Create commit',
+    hasIncreasedVersion && 'Add tag',
+    'Push changes to GitHub',
+    hasIncreasedVersion && 'Push tags to GitHub'
+  ]);
+
+  const changelogPath = `${getRootFolderPath()}/${config.github.changelog.outputPath}`;
+  const packageJsonPath = `${getRootFolderPath()}/package.json`;
+  await exec(`echo git add ${changelogPath} ${packageJsonPath}`, { stdio });
+
+  const packageJsonVersion = getPackageJsonVersion();
+  const commitMessage = hasIncreasedVersion ? packageJsonVersion : 'Update CHANGELOG.md';
+  await exec(`echo git commit -m "${commitMessage}"`, { stdio });
+  status.doneStep(true);
+
+  if (hasIncreasedVersion) {
+    await exec(`echo git tag v${packageJsonVersion}`, { stdio });
+    status.doneStep(true);
+  }
+
+  await exec('echo git push', { stdio });
+  status.doneStep(true);
+
+  if (hasIncreasedVersion) {
+    await exec('echo git push --tags', { stdio });
+    status.doneStep(true);
+  }
+
+};

--- a/src/commitAndPush.js
+++ b/src/commitAndPush.js
@@ -25,23 +25,23 @@ export default async ({ hasIncreasedVersion, hasUpdatedChangelog }) => {
 
   const changelogPath = `${getRootFolderPath()}/${config.github.changelog.outputPath}`;
   const packageJsonPath = `${getRootFolderPath()}/package.json`;
-  await exec(`echo git add ${changelogPath} ${packageJsonPath}`, { stdio });
+  await exec(`git add ${changelogPath} ${packageJsonPath}`, { stdio });
 
   const packageJsonVersion = getPackageJsonVersion();
   const commitMessage = hasIncreasedVersion ? packageJsonVersion : 'Update CHANGELOG.md';
-  await exec(`echo git commit -m "${commitMessage}"`, { stdio });
+  await exec(`git commit -m "${commitMessage}"`, { stdio });
   status.doneStep(true);
 
   if (hasIncreasedVersion) {
-    await exec(`echo git tag v${packageJsonVersion}`, { stdio });
+    await exec(`git tag v${packageJsonVersion}`, { stdio });
     status.doneStep(true);
   }
 
-  await exec('echo git push', { stdio });
+  await exec('git push', { stdio });
   status.doneStep(true);
 
   if (hasIncreasedVersion) {
-    await exec('echo git push --tags', { stdio });
+    await exec('git push --tags', { stdio });
     status.doneStep(true);
   }
 

--- a/src/github/changelog.js
+++ b/src/github/changelog.js
@@ -146,21 +146,15 @@ const generateChangelog = ({ closedIssues, tagsWithCreatedAt }) => {
 const saveChangelog = async changelogMarkdown => {
   info('Save CHANGELOG.md on GitHub');
   status.addSteps([
-    'Save changelog locally',
-    'Update changelog on GitHub'
+    'Save changelog locally'
   ]);
 
   // SAVE changelog
   fs.writeFileSync(`${getRootFolderPath()}/${config.github.changelog.outputPath}`, changelogMarkdown);
   status.doneStep(true);
 
-  // PUSH changes
-  try {
-    await exec(`git add ${config.github.changelog.outputPath}`);
-    await exec('git commit -m "Update CHANGELOG.md"');
-    await exec('git push');
-    status.doneStep(true);
-  } catch (e) {
+  // THROW error if changelog hasn't changed
+  if ((await exec(`git status --porcelain -- ${config.github.changelog.outputPath}`)).trim().length === 0) {
     throw new SmoothReleaseError('CHANGELOG.md hasn\'t changed');
   }
 };

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ import version from './npm/version';
 import publish from './npm/publish';
 import release from './github/release';
 import changelog from './github/changelog';
+import commitAndPush from './commitAndPush';
 import { askForToken } from './github/token';
 import { onError, rl, log } from './utils';
 import config from './config';
@@ -34,19 +35,32 @@ const promptUserBeforeRunningTask = async (task, message) => {
 };
 
 const main = async () => {
+  let hasIncreasedVersion = false;
+  let hasUpdatedChangelog = false;
+
   try {
     !config.github.token && await askForToken();
+
+    await commitAndPush({ hasIncreasedVersion: true, hasUpdatedChangelog: false });
+
+    return;
 
     if (await promptUserBeforeRunningTask('validations', 'Do you want to run the "validations" task?')) {
       await validations();
     }
 
-    if (await promptUserBeforeRunningTask('npm-version', 'Do you want to run the "npm-version" task and increase the version of you library?')) {
+    if (await promptUserBeforeRunningTask('npm-version', 'Do you want to run the "npm-version" task and increase the version of your library?')) {
       await version(mainArgument);
+      hasIncreasedVersion = true;
     }
 
     if (await promptUserBeforeRunningTask('changelog', 'Do you want to run the "changelog" task and update the CHANGELOG.md file?')) {
       await changelog();
+      hasUpdatedChangelog = true;
+    }
+
+    if (hasIncreasedVersion || hasUpdatedChangelog) {
+      await commitAndPush({ hasIncreasedVersion, hasUpdatedChangelog });
     }
 
     if (await promptUserBeforeRunningTask('gh-release', 'Do you want to run the "gh-release" task and create a release on GitHub for the last version of you library?')) {

--- a/src/index.js
+++ b/src/index.js
@@ -41,10 +41,6 @@ const main = async () => {
   try {
     !config.github.token && await askForToken();
 
-    await commitAndPush({ hasIncreasedVersion: true, hasUpdatedChangelog: false });
-
-    return;
-
     if (await promptUserBeforeRunningTask('validations', 'Do you want to run the "validations" task?')) {
       await validations();
     }

--- a/src/npm/version.js
+++ b/src/npm/version.js
@@ -4,6 +4,7 @@ import {
   github,
   isVersionTag,
   getPackageJsonVersion,
+  updatePackageJsonVersion,
   info,
   title,
   log,
@@ -119,8 +120,9 @@ const version = async (releaseInfo) => {
   info('Increase version');
   status.addSteps([
     `Assure tag "v${releaseInfo.version}" doesn\'t already exist`,
-    'Run "npm preversion" and "npm version"',
-    'Push changes and tags to GitHub'
+    'Run "npm preversion"',
+    'Update "package.json"',
+    'Run "npm postversion"'
   ]);
 
   const tagAlreadyExists = await exec(`git rev-parse -q --verify v${releaseInfo.version}`).then(() => true).catch(() => false);
@@ -131,11 +133,13 @@ const version = async (releaseInfo) => {
     status.doneStep(true);
   }
 
-  await exec(`npm version v${releaseInfo.version}`, { stdio });
+  await exec('npm run preversion', { stdio });
   status.doneStep(true);
 
-  await exec('git push', { stdio });
-  await exec('git push --tags', { stdio });
+  updatePackageJsonVersion(releaseInfo.version);
+  status.doneStep(true);
+
+  await exec('npm run postversion', { stdio });
   status.doneStep(true);
 };
 

--- a/src/npm/version.js
+++ b/src/npm/version.js
@@ -4,7 +4,6 @@ import {
   github,
   isVersionTag,
   getPackageJsonVersion,
-  updatePackageJsonVersion,
   info,
   title,
   log,
@@ -120,9 +119,7 @@ const version = async (releaseInfo) => {
   info('Increase version');
   status.addSteps([
     `Assure tag "v${releaseInfo.version}" doesn\'t already exist`,
-    'Run "npm preversion"',
-    'Update "package.json"',
-    'Run "npm postversion"'
+    'Run "npm version --no-git-tag-version"'
   ]);
 
   const tagAlreadyExists = await exec(`git rev-parse -q --verify v${releaseInfo.version}`).then(() => true).catch(() => false);
@@ -133,13 +130,7 @@ const version = async (releaseInfo) => {
     status.doneStep(true);
   }
 
-  await exec('npm run preversion', { stdio });
-  status.doneStep(true);
-
-  updatePackageJsonVersion(releaseInfo.version);
-  status.doneStep(true);
-
-  await exec('npm run postversion', { stdio });
+  await exec(`npm version v${releaseInfo.version} --no-git-tag-version`, { stdio });
   status.doneStep(true);
 };
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -34,7 +34,7 @@ const Status = () => {
     addSteps: newSteps => {
       !done && steps && emptyLine();
 
-      steps = (steps || []).concat(newSteps);
+      steps = (steps || []).concat(newSteps.filter(x => x));
       !done && runNextStep(); // if idle run first step in the list
     },
     doneStep: res => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -93,9 +93,16 @@ const getPackageJson = () => (
   JSON.parse(fs.readFileSync(`${getRootFolderPath()}/package.json`))
 );
 
+export const getPackageJsonName = () => getPackageJson().name;
+
 export const getPackageJsonVersion = () => getPackageJson().version;
 
-export const getPackageJsonName = () => getPackageJson().name;
+export const updatePackageJsonVersion = (version) => {
+  const packageJson = getPackageJson();
+  packageJson.version = version;
+
+  fs.writeFileSync(`${getRootFolderPath()}/package.json`, JSON.stringify(packageJson, null, 2));
+};
 
 
 // OCTOKAT

--- a/src/utils.js
+++ b/src/utils.js
@@ -97,14 +97,6 @@ export const getPackageJsonName = () => getPackageJson().name;
 
 export const getPackageJsonVersion = () => getPackageJson().version;
 
-export const updatePackageJsonVersion = (version) => {
-  const packageJson = getPackageJson();
-  packageJson.version = version;
-
-  fs.writeFileSync(`${getRootFolderPath()}/package.json`, JSON.stringify(packageJson, null, 2));
-};
-
-
 // OCTOKAT
 export const getGithubOwnerAndRepo = () => {
   const remoteOriginUrl = execSync('git config --get remote.origin.url', { encoding: 'utf8' }).trim();


### PR DESCRIPTION
Issue #53

## Test Plan

### tests performed
- `./smooth-release --changelog`
  - correctly throws an error: "Error: CHANGELOG.md hasn't changed"
- mock `commitAndPush` (prefix every command with `echo`)
- run it with `{ hasIncreasedVersion: false, hasUpdatedChangelog: true }`
  - commit message is "Update CHANGELOG.md"
- run it with `{ hasIncreasedVersion: true, hasUpdatedChangelog: true }`
  - commit message is "6.0.0"  (current version taken from `package.json`) ✅ 
- run it with `{ hasIncreasedVersion: true, hasUpdatedChangelog: false }`
  - commit message is "6.0.0"  (current version taken from `package.json`) ✅ 
- mock only push steps, ensure "version" and "changelog" don't throw any error
- run `./smooth-release --no-npm-publish --no-gh-release --no-validations`
  - new commit "7.0.0" with updated package.json and CHANGELOG.md
  - new tag "v7.0.0"

### tests not performed (domain coverage)
I didn't run a complete `./smooth-release`