### PR TITLE
#62: Shouldn't crash if tag already exists (closes #62)

### DIFF
--- a/src/npm/version.js
+++ b/src/npm/version.js
@@ -118,9 +118,18 @@ const confirmation = async releaseInfo => {
 const version = async (releaseInfo) => {
   info('Increase version');
   status.addSteps([
+    `Assure tag "v${releaseInfo.version}" doesn\'t already exist`,
     'Run "npm preversion" and "npm version"',
     'Push changes and tags to GitHub'
   ]);
+
+  const tagAlreadyExists = await exec(`git rev-parse -q --verify v${releaseInfo.version}`).then(() => true).catch(() => false);
+
+  if (tagAlreadyExists) {
+    throw new SmoothReleaseError(`tag "v${releaseInfo.version}" already exists.`);
+  } else {
+    status.doneStep(true);
+  }
 
   await exec(`npm version v${releaseInfo.version}`, { stdio });
   status.doneStep(true);


### PR DESCRIPTION
Issue #62

## Test Plan

### tests performed
- `git tag v10.0.0`
- `./smooth-release 10.0.0 --npm-version`
  - nice error :)

![image](https://cloud.githubusercontent.com/assets/4029499/22306518/dd367e58-e33f-11e6-8ea9-c0a7a8d86859.png)

- `smooth-release 10.0.1 --npm-version`
  - no error, updates `package.json` and adds tag


### tests not performed (domain coverage)
> At times not everything can be tested, and writing what hasn't been tested is just as important as writing what has been tested.

> An example of partial test is a field displaying 4 possible values. If 3 values are tested, with screenshots, and 1 is not, then it should be mentioned here.}
