### PR TITLE
#89: Support ssh repo's remote url (closes #89)

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -112,9 +112,16 @@ const hasBeenInstalledGlobally = () => {
 
 // OCTOKAT
 export const getGithubOwnerAndRepo = () => {
-  const remoteOriginUrl = execSync('git config --get remote.origin.url', { encoding: 'utf8' }).trim();
-
-  const [owner, repo] = remoteOriginUrl.slice(startsWith(remoteOriginUrl, 'https') ? 19 : 15, remoteOriginUrl.length - 4).split('/');
+  const remoteOriginUrl = execSync('git config --get remote.origin.url', {
+    encoding: 'utf8'
+  }).trim();
+  const isSSH = remoteOriginUrl.indexOf('git@') >= 0;
+  let owner, repo;
+  if (isSSH) {
+    [owner, repo] = remoteOriginUrl.replace('.git', '').split(':')[1].split('/');
+  } else {
+    [owner, repo] = remoteOriginUrl.slice(startsWith(remoteOriginUrl, 'https') ? 19 : 15, remoteOriginUrl.length - 4).split('/');
+  }
 
   return { owner, repo };
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -114,14 +114,12 @@ const hasBeenInstalledGlobally = () => {
 export const getGithubOwnerAndRepo = () => {
   const remoteOriginUrl = execSync('git config --get remote.origin.url', {
     encoding: 'utf8'
-  }).trim();
-  const isSSH = remoteOriginUrl.indexOf('git@') >= 0;
-  let owner, repo;
-  if (isSSH) {
-    [owner, repo] = remoteOriginUrl.replace('.git', '').split(':')[1].split('/');
-  } else {
-    [owner, repo] = remoteOriginUrl.slice(startsWith(remoteOriginUrl, 'https') ? 19 : 15, remoteOriginUrl.length - 4).split('/');
-  }
+  }).trim().replace('.git', '');
+
+  const [owner, repo] = remoteOriginUrl.slice(
+    startsWith(remoteOriginUrl, 'https') ? 19 : 15,
+    remoteOriginUrl.length
+  ).split('/');
 
   return { owner, repo };
 };


### PR DESCRIPTION
Closes #89

## Test Plan

### tests performed
Finally :) https://github.com/buildo/scriptoni/commit/a72600c9d1e9d3a386ac001f68285b953b3f4beb

EDIT (by @FrancescoCioria):
- isolated `getGithubOwnerAndRepo` and tested with
  - https **with** `.git` -> ✅ 
  - ssh **with** `.git` -> ✅ 
  - https **without** `.git` -> ✅ 
  - ssh **without** `.git` -> ✅ 

### tests not performed (domain coverage)
> At times not everything can be tested, and writing what hasn't been tested is just as important as writing what has been tested.

> An example of partial test is a field displaying 4 possible values. If 3 values are tested, with screenshots, and 1 is not, then it should be mentioned here.}
