### PR TITLE
#91: Optionally use pull requests instead of issues (closes #91)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Smart CLI utility to **safely** and **automatically** do every step to release a
 Simply run `smooth-release` from your root folder, that's all :)
 
 #### Custom settings
-- Every config value used by `smooth-release` is overridable: jump to [`.smooth-releaserc`](https://github.com/FrancescoCioria/smooth-release#smooth-releaserc) section to know more about it.
-- You can run or turn off specific tasks also by passing a set of CLI arguments: jump to [`CLI arguments`](https://github.com/FrancescoCioria/smooth-release#cli-arguments) section to know more about it.
+- Every config value used by `smooth-release` is overridable: jump to [`.smooth-releaserc`](https://github.com/buildo/smooth-release#smooth-releaserc) section to know more about it.
+- You can run or turn off specific tasks also by passing a set of CLI arguments: jump to [`CLI arguments`](https://github.com/buildo/smooth-release#cli-arguments) section to know more about it.
 
 
 ## What it does
@@ -38,9 +38,11 @@ In order to proceed each one of these validations must pass (they can be optiona
 If a version is "breaking" it will be a `major` otherwise it will be a `patch`.
 `smooth-release` never creates a `minor` version.
 
-To decide if a version is "breaking", `smooth-release` analyzes every closed issue from GitHub: if there is **at least** one *valid* closed issue marked as "breaking" the version will be breaking.
+To decide if a version is "breaking", `smooth-release` analyzes every *closed issue* (or *merged pull request*) from GitHub: if there is **at least** one *valid* closed issue marked as "breaking" the version will be breaking.
 
-To mark an issue as "breaking" you can add to it a label named as you like. This label should also be added to `smooth-releaserc` to let `smooth-release` know about it.
+To mark an *issue* (or *pull request*) as "breaking" you can add to it a label named as you like. This label should also be added to `smooth-releaserc` to let `smooth-release` know about it.
+
+NOTE: you can use *pull requests* instead of *issues* by setting `github.dataType` in `.smooth-releaserc` to `"pullRequests"`
 
 **MANUAL OVERRIDE:**
 If you need to, you can override this step by manually passing the desired version/increase level as argument to `smooth-release`:
@@ -57,11 +59,13 @@ Runs:
 1. `npm version ${newVersion} --no-git-tag-version`
 
 ### Generate CHANGELOG.md
-The script to generate the changelog is basically a replica in JavaScript of [github-changelog-generator](https://github.com/skywinder/github-changelog-generator). The only difference is that it only uses closed issues (PRs are ignored).
+The script to generate the changelog is basically a replica in JavaScript of [github-changelog-generator](https://github.com/skywinder/github-changelog-generator).
 
-This script is stateless: every time it's run it replaces CHANGELOG.md with a new one.
+The changelog is generated using *closed issues* by default. You can use *merged pull requests* instead by setting `github.dataType` in `.smooth-releaserc` to `"pullRequests"`
 
-You can see an example by looking at CHANGELOG.md file on this repo: https://github.com/FrancescoCioria/smooth-release/blob/master/CHANGELOG.md.
+This script is stateless: every time it runs it replaces CHANGELOG.md with a new one.
+
+You can see an example by looking at the CHANGELOG.md file on this repo: https://github.com/buildo/smooth-release/blob/master/CHANGELOG.md.
 
 ### Create release on GitHub with link to CHANGELOG.md section
 It statelessly creates a GitHub release for the last npm-version tag.
@@ -70,7 +74,7 @@ It statelessly creates a GitHub release for the last npm-version tag.
 
 The release is named after the tag (ex: v1.2.3) and the body contains a link to the relative section in CHANGELOG.md.
 
-You can see an example by looking at any release from this repo: https://github.com/FrancescoCioria/smooth-release/releases.
+You can see an example by looking at any release from this repo: https://github.com/buildo/smooth-release/releases.
 
 ### Create release commit and push it on origin
 This step is run only if there are changes to commit. This may happen if you run one of these scripts:
@@ -93,6 +97,7 @@ Runs:
 ```js
 {
   github: {
+    dataType: 'issues',
     changelog: {
       outputPath: './CHANGELOG.md',
       ignoredLabels: ['DX', 'invalid', 'discussion'],

--- a/src/config.js
+++ b/src/config.js
@@ -20,6 +20,7 @@ const smoothReleaseRC = fs.existsSync(smoothReleaseRCPath) ?
 const Config = t.interface({
   github: t.interface({
     token: t.maybe(t.String),
+    dataType: t.maybe(t.enums.of(['issues', 'pullRequests'])),
     changelog: t.interface({
       outputPath: t.String,
       ignoredLabels: t.list(t.String),
@@ -57,6 +58,7 @@ const Config = t.interface({
 
 const defaultConfig = {
   github: {
+    dataType: 'issues',
     changelog: {
       outputPath: './CHANGELOG.md',
       ignoredLabels: ['DX', 'invalid', 'discussion'],

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,7 @@ import packageJson from '../package.json';
 
 const _argv = minimist(process.argv.slice(2));
 
-const { tasks: defaultArgv } = config;
+const { tasks: defaultArgv, github: { dataType } } = config;
 
 const runDefault = !some(Object.keys(defaultArgv), arg => _argv[arg] === true);
 
@@ -53,12 +53,12 @@ const main = async () => {
     }
 
     if (await promptUserBeforeRunningTask('npm-version', 'Do you want to run the "npm-version" task and increase the version of your library?')) {
-      await version(mainArgument);
+      await version({ manualVersion: mainArgument, dataType });
       hasIncreasedVersion = true;
     }
 
     if (await promptUserBeforeRunningTask('changelog', 'Do you want to run the "changelog" task and update the CHANGELOG.md file?')) {
-      await changelog({ hasIncreasedVersion, dataType: config.github.dataType });
+      await changelog({ hasIncreasedVersion, dataType });
       hasUpdatedChangelog = true;
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -58,7 +58,7 @@ const main = async () => {
     }
 
     if (await promptUserBeforeRunningTask('changelog', 'Do you want to run the "changelog" task and update the CHANGELOG.md file?')) {
-      await changelog({ hasIncreasedVersion });
+      await changelog({ hasIncreasedVersion, dataType: config.github.dataType });
       hasUpdatedChangelog = true;
     }
 

--- a/src/modules/getAllMergedPullRequests.js
+++ b/src/modules/getAllMergedPullRequests.js
@@ -1,0 +1,17 @@
+import { github } from '../utils';
+
+const getAllMergedPullRequests = async (acc = [], pullRequests) => {
+  if (!pullRequests) {
+    const firstPage = await github.pulls.fetch({ state: 'closed', limit: 100 });
+    return getAllMergedPullRequests(acc.concat(firstPage), firstPage);
+  } else if (pullRequests.nextPage) {
+    const nextPage = await pullRequests.nextPage();
+    return getAllMergedPullRequests(acc.concat(nextPage), nextPage);
+  } else {
+    return acc.filter(pr => pr.mergedAt); // filter out cloused-without-merge PRs
+  }
+};
+
+export default async () => {
+  return getAllMergedPullRequests();
+};

--- a/src/npm/version.js
+++ b/src/npm/version.js
@@ -63,7 +63,7 @@ const checkIfVersionShouldBeBreaking = async ({ lastVersionTag, dataType }) => {
     }
 
     // VERIFY IF RELEASE SHOULD BE BREAKING
-    const unpublishedBreakingPullRequests = breakingPullRequestsMergedAfterLastTag.filter(i => !lastVersionTagDateTime || i.closedAt >= new Date(lastVersionTagDateTime));
+    const unpublishedBreakingPullRequests = breakingPullRequestsMergedAfterLastTag.filter(i => !lastVersionTagDateTime || i.mergedAt >= new Date(lastVersionTagDateTime));
     return unpublishedBreakingPullRequests.length > 0;
   }
 };

--- a/src/npm/version.js
+++ b/src/npm/version.js
@@ -16,23 +16,10 @@ import {
 
 const stdio = [process.stdin, null, process.stderr];
 
-const computeRelease = async ({ manualVersion, packageJsonVersion }) => {
-  info('Compute release');
-
-  if (!manualVersion) {
-    status.addSteps([
-      'Get all tags from GitHub',
-      'Check if version should be "breaking"',
-      'Compute version'
-    ]);
-
-    // AVOID DUPLICATE PUBLISHED VERSIONS
-    const tags = await github.tags.fetch();
-    status.doneStep(true);
-
+const checkIfVersionShouldBeBreaking = async ({ lastVersionTag, dataType }) => {
+  if (dataType === 'issues') {
     let breakingIssuesUpdatedAfterLastTag = undefined;
     let lastVersionTagDateTime = undefined;
-    const lastVersionTag = find(tags, isVersionTag);
 
     if (lastVersionTag) {
       const lastVersionTagSha = lastVersionTag.commit.sha;
@@ -53,7 +40,52 @@ const computeRelease = async ({ manualVersion, packageJsonVersion }) => {
 
     // VERIFY IF RELEASE SHOULD BE BREAKING
     const unpublishedBreakingIssues = breakingIssuesUpdatedAfterLastTag.filter(i => !lastVersionTagDateTime || i.closedAt >= new Date(lastVersionTagDateTime));
-    const isBreaking = unpublishedBreakingIssues.length > 0;
+    return unpublishedBreakingIssues.length > 0;
+  } else if (dataType === 'pullRequests') {
+    let breakingPullRequestsMergedAfterLastTag = undefined;
+    let lastVersionTagDateTime = undefined;
+
+    if (lastVersionTag) {
+      const lastVersionTagSha = lastVersionTag.commit.sha;
+
+      const tagCommit = await github.commits(lastVersionTagSha).fetch();
+      lastVersionTagDateTime = tagCommit.commit.author.date;
+
+      const pullRequestsMergedAfterLastTag = await github.pulls.fetch({ state: 'closed', since: lastVersionTagDateTime });
+      const unpublishedIssues = pullRequestsMergedAfterLastTag.filter(i => i.mergedAt >= new Date(lastVersionTagDateTime));
+
+      if (unpublishedIssues.length === 0) {
+        throw new SmoothReleaseError('Can\'t find any pull request merged after last publish. Are you sure there are new features to publish?');
+      }
+      breakingPullRequestsMergedAfterLastTag = await github.pulls.fetch({ labels: 'breaking', state: 'closed', since: lastVersionTagDateTime });
+    } else {
+      breakingPullRequestsMergedAfterLastTag = await github.pulls.fetch({ labels: 'breaking', state: 'closed' });
+    }
+
+    // VERIFY IF RELEASE SHOULD BE BREAKING
+    const unpublishedBreakingPullRequests = breakingPullRequestsMergedAfterLastTag.filter(i => !lastVersionTagDateTime || i.closedAt >= new Date(lastVersionTagDateTime));
+    return unpublishedBreakingPullRequests.length > 0;
+  }
+};
+
+const computeRelease = async ({ manualVersion, dataType, packageJsonVersion }) => {
+  info('Compute release');
+
+  if (!manualVersion) {
+    status.addSteps([
+      'Get all tags from GitHub',
+      'Check if version should be "breaking"',
+      'Compute version'
+    ]);
+
+    // AVOID DUPLICATE PUBLISHED VERSIONS
+    const tags = await github.tags.fetch();
+    status.doneStep(true);
+
+
+    // CHECK IF VERSION SHOULD BE BREAKING
+    const lastVersionTag = find(tags, isVersionTag);
+    const isBreaking = await checkIfVersionShouldBeBreaking({ lastVersionTag, dataType });
     status.doneStep(true);
 
     // COMPUTE RELEASE INFO
@@ -134,11 +166,12 @@ const version = async (releaseInfo) => {
   status.doneStep(true);
 };
 
-export default async (manualVersion) => {
+export default async ({ manualVersion, dataType }) => {
   title('Increase version in "package.json"');
 
   const releaseInfo = await computeRelease({
     manualVersion,
+    dataType,
     packageJsonVersion: getPackageJsonVersion()
   });
 

--- a/src/npm/version.js
+++ b/src/npm/version.js
@@ -52,10 +52,10 @@ const checkIfVersionShouldBeBreaking = async ({ lastVersionTag, dataType }) => {
       lastVersionTagDateTime = tagCommit.commit.author.date;
 
       const pullRequestsMergedAfterLastTag = await github.pulls.fetch({ state: 'closed', since: lastVersionTagDateTime });
-      const unpublishedIssues = pullRequestsMergedAfterLastTag.filter(i => i.mergedAt >= new Date(lastVersionTagDateTime));
+      const unpublishedMergedPullRequests = pullRequestsMergedAfterLastTag.filter(i => i.mergedAt >= new Date(lastVersionTagDateTime));
 
-      if (unpublishedIssues.length === 0) {
-        throw new SmoothReleaseError('Can\'t find any pull request merged after last publish. Are you sure there are new features to publish?');
+      if (unpublishedMergedPullRequests.length === 0) {
+        throw new SmoothReleaseError('Can\'t find any merged pull request after last publish. Are you sure there are new features to publish?');
       }
       breakingPullRequestsMergedAfterLastTag = await github.pulls.fetch({ labels: 'breaking', state: 'closed', since: lastVersionTagDateTime });
     } else {


### PR DESCRIPTION
Closes #91

## Test Plan

### tests performed
- dataType: issues or none (defaults to issues)
  - npm version correctly detects breaking with closed issues
  - changelog correctly generated with closed issues
- dataType: pullRequests
  - npm version correctly detects breaking with merged PRs
  - changelog correctly generated with merged PRs

### tests not performed (domain coverage)
> At times not everything can be tested, and writing what hasn't been tested is just as important as writing what has been tested.

> An example of partial test is a field displaying 4 possible values. If 3 values are tested, with screenshots, and 1 is not, then it should be mentioned here.}
