### PR TITLE
#98: human validation of computed version should be optional (closes #98)

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -44,7 +44,8 @@ const Config = t.interface({
     noUntrackedFiles: t.Boolean,
     validNpmCredentials: t.Boolean,
     validGithubToken: t.Boolean,
-    packageFilesFilter: t.union([t.enums.of(['npmignore', 'files']), t.Boolean])
+    packageFilesFilter: t.union([t.enums.of(['npmignore', 'files']), t.Boolean]),
+    npmVersionConfirmation: t.Boolean
   }),
   tasks: t.interface({
     changelog: t.maybe(t.Boolean),
@@ -54,7 +55,7 @@ const Config = t.interface({
     'gh-release': t.maybe(t.Boolean),
     'gh-release-all': t.maybe(t.Boolean)
   })
-});
+}, { name: 'SmoothReleaseRC' });
 
 const defaultConfig = {
   github: {
@@ -82,7 +83,8 @@ const defaultConfig = {
     noUntrackedFiles: true,
     validNpmCredentials: true,
     validGithubToken: true,
-    packageFilesFilter: 'files'
+    packageFilesFilter: 'files',
+    npmVersionConfirmation: true
   },
   tasks: {
     validations: true,

--- a/src/npm/version.js
+++ b/src/npm/version.js
@@ -13,6 +13,7 @@ import {
   rl,
   exec
 } from '../utils';
+import config from '../config';
 
 const stdio = [process.stdin, null, process.stderr];
 
@@ -175,7 +176,9 @@ export default async ({ manualVersion, dataType }) => {
     packageJsonVersion: getPackageJsonVersion()
   });
 
-  await confirmation(releaseInfo);
+  if (config.publish.npmVersionConfirmation) {
+    await confirmation(releaseInfo);
+  }
 
   await version(releaseInfo);
 };


### PR DESCRIPTION
Closes #98

## Test Plan

### tests performed
- ignore new config
  - asks for confirmation
- pass `true`
  - asks for confirmation
- pass `false`
  - does not ask for confirmation
- pass a value different from `true` or `false`
  - config error

### tests not performed (domain coverage)
> At times not everything can be tested, and writing what hasn't been tested is just as important as writing what has been tested.

> An example of partial test is a field displaying 4 possible values. If 3 values are tested, with screenshots, and 1 is not, then it should be mentioned here.}
