### PR TITLE
#113: `publish` with `pack` does not work for organization's packages (closes #113)

### DIFF
--- a/src/npm/publish.js
+++ b/src/npm/publish.js
@@ -65,7 +65,10 @@ async function publish(useTarPackage, tarPackageFilename, tarPackageFilePath) {
 export default async () => {
   title('Publish package on npm');
 
-  const tarPackageFilename = `${getPackageJsonName()}-${getPackageJsonVersion()}.tgz`;
+  const packageJsonName = getPackageJsonName();
+  const cleanedPackageJsonName = packageJsonName.startsWith('@') ? packageJsonName.replace('@', '').replace('/', '-') : packageJsonName;
+
+  const tarPackageFilename = `${cleanedPackageJsonName}-${getPackageJsonVersion()}.tgz`;
   const tarPackageFilePath = path.resolve(getRootFolderPath(), tarPackageFilename);
 
   if (config.publish.tarPackageConfirmation) {


### PR DESCRIPTION
Closes #113

## Test Plan

### tests performed

verified `tarPackageFilePath` for scoped and non scoped packageJsonName

### tests not performed (domain coverage)

> At times not everything can be tested, and writing what hasn't been tested is just as important as writing what has been tested.

> An example of partial test is a field displaying 4 possible values. If 3 values are tested, with screenshots, and 1 is not, then it should be mentioned here.
